### PR TITLE
Update dependencies, builds with ghc 9.2.2

### DIFF
--- a/changelog-d.cabal
+++ b/changelog-d.cabal
@@ -13,7 +13,7 @@ license:       GPL-3.0-or-later
 license-file:  LICENSE
 author:        Oleg Grenrus <oleg.grenrus@iki.fi>
 maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
-tested-with:   GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1
+tested-with:   GHC ==8.4.4 || ==8.6.5 || ==8.8.3 || ==8.10.1 || ==9.2.2
 
 source-repository head
   type:     git
@@ -25,9 +25,9 @@ library changelog-d-internal
 
   -- GHC boot libraries
   build-depends:
-    , base        ^>=4.11.1.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0
-    , bytestring  ^>=0.10.8.2
-    , Cabal       ^>=3.2.0.0
+    , base        ^>=4.11.1.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.16.1.0
+    , bytestring  ^>=0.10.8.2 || ^>=0.11.3.0
+    , Cabal       ^>=3.6.3.0
     , containers  ^>=0.5.11.0 || ^>=0.6.0.1
     , directory   ^>=1.3.1.5
     , filepath    ^>=1.4.2
@@ -37,7 +37,7 @@ library changelog-d-internal
 
   -- extra dependencies
   build-depends:
-    , cabal-install-parsers  ^>=0.3
+    , cabal-install-parsers  ^>=0.3 || ^>=0.4.5
     , generic-lens-lite      ^>=0.1
     , regex-applicative      ^>=0.3.3.1
 
@@ -73,4 +73,5 @@ executable changelog-d
     , filepath
 
   -- extra dependencies
-  build-depends:    optparse-applicative >=0.14.3.0 && <0.16
+  build-depends:
+    optparse-applicative >=0.14.3.0 && <0.16 || >=0.17.0.0 && <0.18

--- a/src/ChangelogD.hs
+++ b/src/ChangelogD.hs
@@ -42,7 +42,6 @@ import qualified Distribution.Compat.CharParsing as P
 import qualified Distribution.FieldGrammar       as C
 import qualified Distribution.Fields             as C
 import qualified Distribution.Parsec             as C
-import qualified Distribution.Parsec.Newtypes    as C
 import qualified Distribution.Pretty             as C
 import qualified Distribution.Simple.Utils       as C
 import qualified Distribution.Types.PackageName  as C


### PR DESCRIPTION
Tested by running
cabal build --constraint optparse-applicative==0.17.0.0 --constraint cabal-install-parsers==0.4.5 --constraint Cabal==3.6.3.0 --constraint bytestring==0.11.3.0 --constraint base==4.16.1.0